### PR TITLE
Removes assocRules dict from runApriori() function

### DIFF
--- a/apriori.py
+++ b/apriori.py
@@ -70,9 +70,6 @@ def runApriori(data_iter, minSupport, minConfidence):
     # Global dictionary which stores (key=n-itemSets,value=support)
     # which satisfy minSupport
 
-    assocRules = dict()
-    # Dictionary which stores Association Rules
-
     oneCSet = returnItemsWithMinSupport(itemSet,
                                         transactionList,
                                         minSupport,


### PR DESCRIPTION
Removed the two lines from runApriori() function:
    assocRules = dict()
    # Dictionary which stores Association Rules
assocRules was never used